### PR TITLE
A blank search page is no longer super broken.

### DIFF
--- a/apps/links/tests/test_search_results.py
+++ b/apps/links/tests/test_search_results.py
@@ -125,6 +125,22 @@ class LinkSearchResults(WebTest):
         )
         self.assertIsNotNone(csv_download_link)
 
+    def test_search_with_no_query_is_valid(self):
+        empty_search_url = reverse('search')
+        response = self.app.get(empty_search_url)
+        form = response.form
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(form['q'].value, '')
+
+    def test_search_with_empty_query_is_valid(self):
+        empty_search_url = '%s?q=' % reverse('search')
+        response = self.app.get(empty_search_url)
+        form = response.form
+
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(form['q'].value, '')
+
     def test_search_stats_csv(self):
         self.test_search_twice_with_different_terms()
 

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -72,8 +72,10 @@ class SearchStatsCSV(View):
 def search(request):
     view = SearchView()
     response = view(request)
+    has_query = 'q' in request.GET
+    not_on_page = 'page' not in request.GET
 
-    if 'page' not in request.GET:
+    if has_query and len(request.GET.get('q')) > 0 and not_on_page:
         st, created = SearchTerm.objects.get_or_create(
             query=request.GET.get('q')
         )

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -8,7 +8,7 @@
   <h1 class="form-title heading-xlarge">Tools</h1>
 
   <form class="form-group two-thirds-inline-search-form" action='/search/' method='get'>
-    <input class="form-control search-box" id='q' type="text" value="{{ form.q.value }}" name='q' tabindex="1" autofocus="true" />
+    <input class="form-control search-box" id='q' type="text" value="{{ form.q.value|default_if_none:'' }}" name='q' tabindex="1" autofocus="true" />
     <button class="button search-button" type="submit">Search</button>
   </form>
 


### PR DESCRIPTION
Because of the whole 'storing queries' thing an empty search page caused a 500, because
no search query was there to be stored. Also, when that problem _was_ fixed it caused
another problem whereby the word 'None' appeared in the search box, since the value of
the context variable, 'q', was indeed None. So I fixed that too. There are also two new
tests to verify that this behaviour does not change, one for each of the cases that either
the querystring param q does not exist, or that it is empty. :thumbsup:

Completes https://trello.com/c/0EPtAVB2/394-search-page-should-probably-not-throw-an-error
