### PR TITLE
No longer showing the 20 most recent searches, CSV added

### DIFF
--- a/apps/links/tests/test_search_results.py
+++ b/apps/links/tests/test_search_results.py
@@ -52,18 +52,6 @@ class LinkSearchResults(WebTest):
         results = response.html.find(id='search-results').findAll('li')
         self.assertEquals(len(results), 3)
 
-        response = self.app.get(reverse('search-stats'))
-        search_queries_table = response.html.find(
-            None,
-            {"id": "latest-20-searches"}
-        )
-        search_queries_rows = search_queries_table.findChildren('tr')
-        self.assertEquals(len(search_queries_rows), 2)
-
-        self.assertIn('google', search_queries_rows[1].text)
-        self.assertIn('3', search_queries_rows[1].text)
-        self.assertIn('01/03/2016, 10:00', search_queries_rows[1].text)
-
     def test_search_for_first_shows_one(self):
         search_url = '%s?q=search' % reverse('search')
         response = self.app.get(search_url)
@@ -99,20 +87,6 @@ class LinkSearchResults(WebTest):
         self.assertEquals(len(results), 1)
 
         response = self.app.get(reverse('search-stats'))
-        search_queries_table = response.html.find(
-            None,
-            {"id": "latest-20-searches"}
-        )
-        search_queries_rows = search_queries_table.findChildren('tr')
-        self.assertEquals(len(search_queries_rows), 3)
-
-        self.assertIn('chat', search_queries_rows[1].text)
-        self.assertIn('1', search_queries_rows[1].text)
-        self.assertIn('01/03/2016, 10:02', search_queries_rows[1].text)
-
-        self.assertIn('flibble', search_queries_rows[2].text)
-        self.assertIn('0', search_queries_rows[2].text)
-        self.assertIn('01/03/2016, 10:00', search_queries_rows[2].text)
 
         csv_download_link = response.html.find(
             None,

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -6,19 +6,16 @@ from datetime import timedelta
 from django.db.models import Count
 from django.http import HttpResponse
 from django.utils import timezone
-from django.views.generic import ListView, View
+from django.views.generic import TemplateView, View
 
 from haystack.views import SearchView
 
 from .models import SearchQuery, SearchTerm
 
 
-class SearchStats(ListView):
+class SearchStats(TemplateView):
     model = SearchQuery
     template_name = 'search/search_stats.html'
-
-    def get_queryset(self):
-        return SearchQuery.objects.order_by('-when')[:20]
 
     def get_context_data(self, **kwargs):
         context = super(SearchStats, self).get_context_data(**kwargs)

--- a/templates/search/search_stats.html
+++ b/templates/search/search_stats.html
@@ -9,32 +9,11 @@
     <span class="heading-secondary">Tools</span>
     Search stats
   </h1>
-
-  <h2 class="heading-medium">Most popular search terms</h2>
-
-  <p>
-    Download
-    <a id="csv-download-all" href='{% url "search-stats-csv" %}'>full usage stats</a>
-     as a CSV file</a>.
+  <p class="lede">
+    This page contains a summary of the most popular search terms of the last thirty days, as well as the most popular unfulfilled search terms.<br>The full search statistics are also available as
+    <a href='{% url "search-stats-csv" %}'>a CSV file</a> which includes each query's term, date and the username of the user who performed the search.
   </p>
-
-  <table id="latest-20-searches">
-    <tr>
-      <th>Search term</th>
-      <th>Time of search</th>
-      <th>Number of results</th>
-    </tr>
-    {% for query in object_list %}
-    <tr>
-      <td class='search-term'>{{query.term}}</td>
-      <td class='search-time'>{{query.when|date:"d/m/Y, H:i"}}</td>
-      <td class='results'>{{query.results_length}}</td>
-    </tr>
-    {% endfor %}
-  </table>
-
-
-  <div class="grid-row">
+  <div class="grid-row statistics-grid">
     <div class="column-half">
       <h2 class="heading-medium">Top terms in the last 30 days</h2>
       <p>These are the most searched-for terms in the last 30 days which have returned any number of results.</p>
@@ -67,6 +46,9 @@
         {% endfor %}
       </table>
     </div>
+  </div>
+  <div class="form-group">
+    <a class="button" id="csv-download-all" href="{% url "search-stats-csv" %}">Download CSV of all search queries</a>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
Since the 20 most recent searches are no longer being shown there's no need for
the search stats view to be a listview so it's a templateview now. Also, I added some
lede texts to that page explaining what it is plus a CSV link with explanation.
A CSV CTA is now also sitting beneath the table.

![image](https://cloud.githubusercontent.com/assets/516325/14111228/d15ab066-f5c1-11e5-8178-a62c91158d69.png)
