### PR TITLE
Removed the cookie banner and any code which relies on it.

### DIFF
--- a/apps/govuk_template/templates/base.htm
+++ b/apps/govuk_template/templates/base.htm
@@ -66,14 +66,6 @@
         <a href="#content" class="skiplink">{{ skip_link_message|default:'Skip to main content' }}</a>
       </div>
     </div>
-
-    <div id="global-cookie-message">
-      
-        {% block cookie_message %}{% endblock %}
-      
-    </div>
-    <!--end global-cookie-message-->
-
     
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">

--- a/templates/base.htm
+++ b/templates/base.htm
@@ -67,14 +67,6 @@
         <a href="#content" class="skiplink">{{ skip_link_message|default:'Skip to main content' }}</a>
       </div>
     </div>
-
-    <div id="global-cookie-message">
-      
-        {% block cookie_message %}{% endblock %}
-      
-    </div>
-    <!--end global-cookie-message-->
-
     
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
@@ -119,8 +111,6 @@
     <!--end footer-->
 
     <div id="global-app-error" class="app-error hidden"></div>
-
-    <script src="{% static 'javascripts/govuk-template.js' %}" type="text/javascript"></script>
 
     {% block body_end %}{% endblock %}
   </body>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,13 +9,6 @@
     {% endcompress %}
 {% endblock %}
 
-{% block cookie_message %}
-  <p>
-    Lighthouse uses cookies to make the site simpler.
-    <a href='#'>Find out more about cookies</a>
-  </p>
-{% endblock %}
-
 {% block global_header_text %}
 [dstl]
 {% endblock %}


### PR DESCRIPTION
There's some GOV.UK code which will handle the 'user has seen the cookie banner' thing,
which naturally will add a cookie. I left the code in the repo because it's vendor
code, but I removed it from our base.htm layout file because it wasn't being used. What
we've lost then is the ability to easily set a cookie on the front end, but that's OK and
if we need it later we can add it back in.

completes https://trello.com/c/pqjZRZOb/337-remove-cookie-banner
