### PR TITLE
Simple fix to the all user list footer.

### DIFF
--- a/templates/users/user_list.html
+++ b/templates/users/user_list.html
@@ -45,4 +45,5 @@
     {% include "includes/top_organisations.html" %}
     {% include "includes/top_teams.html" %}
   </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
There was a missing </div> there which meant the grid row div never closed and it confused browsers when they tried to render the footer.

![image](https://cloud.githubusercontent.com/assets/516325/14112650/73585d14-f5c7-11e5-9579-54e33ef0d2f8.png)

Completes https://trello.com/b/7tuSboqt/dstl-lighthouse-backlog
