### PR TITLE
An edit link is now available for tool owners

### DIFF
--- a/apps/links/tests/common.py
+++ b/apps/links/tests/common.py
@@ -23,13 +23,17 @@ def generate_fake_links(owner, start=1, count=1, is_external=False):
         yield link
 
 
-def make_user():
-    user = User(
-        slug='user0001com',
+def make_user(
         original_slug='user@0001.com',
-        username='Fake Fakerly',
+        email='fake@dstl.gov.uk',
+        name='Fake Fakerly'):
+    slug = original_slug.replace('@', '').replace('.', '')
+    user = User(
+        slug=slug,
+        original_slug=original_slug,
+        username=name,
         phone='555-2187',
-        email='fake@dstl.gov.uk')
+        email=email)
     user.save()
     return user
 
@@ -38,7 +42,7 @@ def login_user(owner, user):
 
     #   Log in as user
     form = owner.app.get(reverse('login-view')).form
-    form['slug'] = 'user0001com'
+    form['slug'] = user.slug
     response = form.submit().follow()
 
     user_id = response.html.find(

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -26,6 +26,11 @@ from apps.access import LoginRequiredMixin
 class LinkDetail(DetailView):
     model = Link
 
+    def get_context_data(self, **kwargs):
+        context = super(LinkDetail, self).get_context_data(**kwargs)
+        context['user_owns_link'] = self.request.user == self.object.owner
+        return context
+
 
 class LinkRedirect(DetailView):
     model = Link

--- a/templates/links/link_detail.html
+++ b/templates/links/link_detail.html
@@ -92,6 +92,12 @@
             {{link.name}} was created by <a href="{% url "user-detail" link.owner.slug %}">{{link.owner.username|default:link.owner.original_slug}}</a>.
         </p>
         {% endif %}
+        {% if user_owns_link %}
+        <p>
+            Since you added it, you have permission to edit this tool.
+        </p>
+        <a class="button" id="edit-button" href="{% url "link-edit" link.id %}">Edit this tool</a>
+        {% endif %}
         <h2 class="heading-medium">Categories</h2>
         {% if link.categories.count %}
         <ul>


### PR DESCRIPTION
I put a little bit of explanatory text and a nice green CTA. There's a test to cover it
which involved modifying some common test code so that it can take some non-default params,
just so I could make a new user to log in with. :tada:

![image](https://cloud.githubusercontent.com/assets/516325/14114212/1190f4cc-f5ce-11e5-8ccd-005ed56ff2e2.png)

Completes https://trello.com/c/KQkl129u/376-edit-button-missing-on-tools-page-for-owner
