### PR TITLE
Width of content wrapper removed.

### DIFF
--- a/sass/application.scss
+++ b/sass/application.scss
@@ -71,11 +71,6 @@ $path: "/static/";
 @import "statistics";
 @import "markdown-content";
 
-#content {
-	width:960px;
-	margin:0 auto;
-}
-
 .button-secondary {
   @include button($grey-3);
   @include box-sizing (border-box);


### PR DESCRIPTION
A wrapper called #content was put in a while ago to keep the width
of the page consistent before we started using loads of GOV.UK stuff but
it is no longer helpful. In fact, it is hindering us. So it is no more. The site
will leave the job of width and centering to the tried-and-tested GOV.UK styles and it is now capable
of resizing far more comfortably, and will adapt to various screen sizes.

@michaeldfallen this is what you had pointed out!
