### PR TITLE
Leave & Join buttons now POST, not GET

### DIFF
--- a/apps/login/views.py
+++ b/apps/login/views.py
@@ -16,7 +16,6 @@ from apps.users.models import User
 #   TODO: There's a fair amount of refactoring we can do around this, but
 #   that's probably best left for when we do LDAP stuff
 def LogUserIn(self, request, slug):
-    # pdb.set_trace()
     #   See if we an authenticate the user
     try:
         user = authenticate(slug=slugify(slug))

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -69,7 +69,7 @@ class TeamDetail(LoginRequiredMixin, DetailView):
 
 class TeamJoin(LoginRequiredMixin, TemplateView):
 
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
 
         #   If we are not logged in, send the user to the login page
         if not self.request.user.is_authenticated():
@@ -96,7 +96,7 @@ class TeamJoin(LoginRequiredMixin, TemplateView):
 
 class TeamLeave(LoginRequiredMixin, TemplateView):
 
-    def get(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
 
         #   If we are not logged in, send the user to the login page
         if not self.request.user.is_authenticated():

--- a/templates/teams/team_detail.html
+++ b/templates/teams/team_detail.html
@@ -35,9 +35,15 @@
     {% if request.user.slug %}
     <hr />
     {% if team_member %}
-      <a href="{% url "team-leave" team.pk %}" class="button">Leave team</a>
+      <form action="{% url "team-leave" team.pk %}" method="post">
+        {% csrf_token %}
+        <input type="submit" value="Leave team" class="button" />
+      </form>
     {% else %}
-      <a href="{% url "team-join" team.pk %}" class="button">Join team</a>
+      <form action="{% url "team-join" team.pk %}" method="post">
+        {% csrf_token %}
+        <input type="submit" value="Join team" class="button" />
+      </form>
     {% endif %}
     {% endif %}
 


### PR DESCRIPTION
The leave team/join team buttons were actually just `<a>` links which
pointed to the leave and join links for that team. It is more
appropriate that they should be buttons whose parent form will POST to
the leave or join endpoint which should be an RPC-style endpoint because
GET requests are not meant to be destructive.

So that's what I've implemented. I had to modify the existing leave/join
tests to do it, and also put in some asserts to ensure that the old
leave/join buttons had been removed, too. They look exactly the same.
The only real change was to change on the backend was to change the
word `get` to `post`.

:snake:

Completes https://trello.com/c/wNdoVt4N/391-some-actions-eg-user-leaving-a-team-are-being-done-on-get-requests-and-should-be-post
