### PR TITLE
Copy and headings on tool and tool search pages

### DIFF
--- a/templates/links/link_list.html
+++ b/templates/links/link_list.html
@@ -7,10 +7,11 @@
 
 <h1 class="form-title heading-xlarge">
   <span class="heading-secondary">Tools</span>
+  All tools
 </h1>
 
+{% if total_links_in_db > 0 %}
 <div class="grid-row">
-  {% if total_links_in_db > 0 %}
   <div id="categories-filter" class="column-third">
     <form method="get" action="" id="list-results">
       <h2 class="filter-controls-header heading-medium heading-snug-top">Tool categories</h2>
@@ -84,17 +85,14 @@
       {% include "includes/pagination.html" %}
 
     </div>
-  {% else %}
-    <div class="alert-summary" role="group">
-      <h3 class="heading-medium alert-summary-heading">No tools added yet.</h3>
-      <p>
-        Hey there, it doesn't look like any tools have been added to the system yet. That means you're a super early adopter!
-      </p>
-      <p>
-        To get started you can add the 1st tool here: <a href="{% url 'link-create' %}">Add a new tool</a>.
-      </p>
-    </div>
-  {% endif %}
-
 </div>
+{% else %}
+<div class="alert-summary" role="group">
+  <h3 class="heading-medium alert-summary-heading">No tools have been added yet</h3>
+  <p>
+    The system doesn't yet have any tools recorded. Add the first tool, visit the "<a href="{% url 'link-create' %}">Add a new tool</a>" page.
+  </p>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -5,7 +5,10 @@
 
 {% block grid_content %}
 
-  <h1 class="form-title heading-xlarge">Tools</h1>
+  <h1 class="form-title heading-xlarge">
+    <span class="heading-secondary">Tools</span>
+    Search for tools
+  </h1>
 
   <form class="form-group two-thirds-inline-search-form" action='/search/' method='get'>
     <input class="form-control search-box" id='q' type="text" value="{{ form.q.value|default_if_none:'' }}" name='q' tabindex="1" autofocus="true" />


### PR DESCRIPTION
They both needed a secondary/primary heading fix, and the empty state for the
tool page was looking a little messy. It had fallen out of the grid and the
copy felt a bit too casual for my liking.
### All tools now

![image](https://cloud.githubusercontent.com/assets/516325/14249805/7602341c-fa73-11e5-92d4-597e4f9dd7f9.png)
### Search for tools now

![image](https://cloud.githubusercontent.com/assets/516325/14249807/7ab77ee0-fa73-11e5-9207-a1602e0ef065.png)
