### PR TITLE
Add duration to usage stats

### DIFF
--- a/apps/api/documentation/link-usage.md
+++ b/apps/api/documentation/link-usage.md
@@ -9,7 +9,13 @@
 ## GET
 
 An HTTP GET request will return a JSON array of usage stats for the given 
-tool's `:id`.
+tool's `:id`. The data structure contains the following fields:
+
+* `user` — the ID of the user
+* `date` — the timestamp when the user started using the tool
+* `duration` — how long they used it for. A value of 0 means that that
+    tool does not update lighthouse during active usage.
+
 
 **Arguments**: The ID of the tool in the URL.
 
@@ -17,9 +23,13 @@ tool's `:id`.
 
     $ curl http://lighthouse_host/api/links/1/usage
     [
-        {"user": "alice", "date": "2016-03-04T14:53:25.740Z"},
-        {"user": "bob", "date": "2016-03-04T14:53:35.143Z"},
-        {"user": "claire", "date": "2016-03-04T15:16:12.000Z"}
+        {"user": "alice", "date": "2016-03-04T14:53:25.740Z", "duration": 0},
+        {"user": "claire", "date": "2016-03-04T15:16:12.000Z", "duration": 0}
+    ]
+
+    $ curl http://lighthouse_host/api/links/2/usage
+    [
+        {"user": "bob", "date": "2016-03-04T14:53:35.143Z", "duration": 3420}
     ]
 
 **Python example**:
@@ -30,9 +40,14 @@ tool's `:id`.
     200
     >>> response.json()
     [
-        {u'user': 'alice', 'date': '2016-03-04T14:53:25.740Z'},
-        {u'user': 'bob', 'date': '2016-03-04T14:53:35.143Z'},
-        {u'user': 'claire', 'date': '2016-03-04T15:16:12.000Z'}
+        {u'user': 'alice', 'date': '2016-03-04T14:53:25.740Z', 'duration': 0},
+        {u'user': 'claire', 'date': '2016-03-04T15:16:12.000Z', 'duration': 0}
+    ]
+
+    >>> response = requests.get('http://lighthouse_host/api/links/2/usage')
+    >>> response.json()
+    [
+        {u'user': 'bob', 'date': '2016-03-04T14:53:35.143Z', 'duration': 3420}
     ]
 
 **Response codes**
@@ -44,6 +59,10 @@ tool's `:id`.
 
 An HTTP POST request will add a new usage statistic for the given 
 tool's `:id`.
+
+If it is received within one hour of the last time that user's usage stat was
+posted it will cause lighthouse to update that usage with a duration, rather
+than create a new usage data point.
 
 **Arguments**: The ID of the tool in the URL. The `user` parameter, sent
 form encoded.

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -60,6 +60,7 @@ class LinkUsageAPI(SingleObjectMixin, APIBase):
             response.append({
                 'user': use.user.userid,
                 'date': use.start,
+                'duration': use.duration,
             })
         return JsonResponse(response, safe=False)
 

--- a/apps/links/migrations/0002_linkusage_end.py
+++ b/apps/links/migrations/0002_linkusage_end.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('links', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='linkusage',
+            name='end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/apps/links/tests/test_usage_by_team_and_org.py
+++ b/apps/links/tests/test_usage_by_team_and_org.py
@@ -62,51 +62,27 @@ class LinkUsageByUserTest(WebTest):
         )
         l1.save()
 
-        #   Now we need to log in each user and get them to click the external
-        #   link button a few times each.
+        #   Now we need to log the activity of each user.
         #
         #   User 1, is going to use the tool 4 times.
+        for i in range(0, 4):
+            l1.register_usage(user=u1, force_new=True)
+
         #   User 2, is going to use the tool 2 times.
+        for i in range(0, 2):
+            l1.register_usage(user=u2, force_new=True)
+
         #   User 3, is going to use the tool 5 times.
+        for i in range(0, 5):
+            l1.register_usage(user=u3, force_new=True)
 
         #   Login as the first user
         form = self.app.get(reverse('login')).form
         form['userid'] = 'user0001'
         form.submit()
 
-        interstitial_page_form = self.app.get(
-            reverse('link-redirect', kwargs={'pk': l1.pk})).follow().form
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-
-        #   Login as the second user
-        form = self.app.get(reverse('login')).form
-        form['userid'] = 'user0002'
-        form.submit()
-
-        interstitial_page_form = self.app.get(
-            reverse('link-redirect', kwargs={'pk': l1.pk})).follow().form
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-
-        #   Login as the third user
-        form = self.app.get(reverse('login')).form
-        form['userid'] = 'user0003'
-        form.submit()
-
-        interstitial_page_form = self.app.get(
-            reverse('link-redirect', kwargs={'pk': l1.pk})).follow().form
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-        interstitial_page_form.submit().follow()
-
-        #   Now we've done all the clicks, lets go an have a look at the
-        #   details page, and check out the teams and organisations usage
-        #   count.
+        #   Now lets go an have a look at the details page, and check
+        #   out the teams and organisations usage count.
         details_page = self.app.get(
             reverse('link-detail', kwargs={'pk': l1.pk}))
 

--- a/apps/links/tests/test_usage_by_user.py
+++ b/apps/links/tests/test_usage_by_user.py
@@ -14,7 +14,7 @@ from testing.common import generate_fake_links
 
 def register_link_usage_for_user(link, user, num_usage):
     for u in range(0, num_usage):
-        link.register_usage(user)
+        link.register_usage(user, force_new=True)
 
 
 class LinkUsageByUserTest(WebTest):
@@ -84,11 +84,11 @@ class LinkUsageByUserTest(WebTest):
         with mock.patch('django.utils.timezone.now') as mock_now:
             # Register additional usage, just within the window
             mock_now.return_value = self.now - relativedelta(days=29)
-            self.used_link.register_usage(self.top_user_1)
+            self.used_link.register_usage(self.top_user_1, force_new=True)
 
             # Register additional usage, AGES ago (just outside window)
             mock_now.return_value = self.now - relativedelta(days=31)
-            self.used_link.register_usage(self.top_user_1)
+            self.used_link.register_usage(self.top_user_1, force_new=True)
 
         response = self.app.get(
             reverse('link-detail', kwargs={'pk': self.used_link.pk})

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -250,10 +250,11 @@ class LinkStatsCSV(DetailView):
             )
 
         writer = csv.writer(response)
-        writer.writerow(['Date', 'User', 'Tool'])
+        writer.writerow(['Date', 'Duration', 'User', 'Tool'])
         for usage in link.usage.all():
             writer.writerow([
                 usage.start.strftime("%Y-%m-%d %H:%M:%S"),
+                usage.duration,
                 usage.user.userid,
                 usage.link
             ])
@@ -280,10 +281,11 @@ class OverallLinkStatsCSV(View):
             'attachment; filename="lighthouse_full_%s.csv"' % date
 
         writer = csv.writer(response)
-        writer.writerow(['Date', 'User', 'Tool'])
+        writer.writerow(['Date', 'Duration', 'User', 'Tool'])
         for usage in LinkUsage.objects.all():
             writer.writerow([
                 usage.start.strftime("%Y-%m-%d %H:%M:%S"),
+                usage.duration,
                 usage.user.userid,
                 usage.link
             ])

--- a/apps/organisations/tests/test_organisation_detail.py
+++ b/apps/organisations/tests/test_organisation_detail.py
@@ -158,39 +158,39 @@ class OrganisationDetailWebTest(WebTest):
         # increase the aggregate from values across teams.
         # 16 times for existing link 8
         for i in range(0, 6):
-            self.el8.register_usage(user1)
+            self.el8.register_usage(user1, force_new=True)
         for i in range(0, 10):
-            self.el8.register_usage(user2)
+            self.el8.register_usage(user2, force_new=True)
 
         # 13 times for existing link 4
         for i in range(0, 8):
-            self.el4.register_usage(user1)
+            self.el4.register_usage(user1, force_new=True)
         for i in range(0, 5):
-            self.el4.register_usage(user2)
+            self.el4.register_usage(user2, force_new=True)
 
         # 9 times for existing link 1
         for i in range(0, 4):
-            self.el1.register_usage(user1)
+            self.el1.register_usage(user1, force_new=True)
         for i in range(0, 5):
-            self.el1.register_usage(user2)
+            self.el1.register_usage(user2, force_new=True)
 
         # 8 times for existing link 3
         for i in range(0, 5):
-            self.el3.register_usage(user1)
+            self.el3.register_usage(user1, force_new=True)
         for i in range(0, 3):
-            self.el3.register_usage(user2)
+            self.el3.register_usage(user2, force_new=True)
 
         # 4 times for existing link 9
         for i in range(0, 3):
-            self.el9.register_usage(user1)
+            self.el9.register_usage(user1, force_new=True)
         for i in range(0, 1):
-            self.el9.register_usage(user2)
+            self.el9.register_usage(user2, force_new=True)
 
         # 3 times for existing link 10
         for i in range(0, 2):
-            self.el10.register_usage(user1)
+            self.el10.register_usage(user1, force_new=True)
         for i in range(0, 1):
-            self.el10.register_usage(user2)
+            self.el10.register_usage(user2, force_new=True)
 
         response = self.app.get(reverse(
             'organisation-detail',

--- a/apps/teams/tests/test_team_details.py
+++ b/apps/teams/tests/test_team_details.py
@@ -34,22 +34,22 @@ class TeamToolUsageTests(WebTest):
         )
 
         for i in range(0, 8):
-            self.el4.register_usage(user1)
+            self.el4.register_usage(user1, force_new=True)
 
         for i in range(0, 6):
-            self.el8.register_usage(user1)
+            self.el8.register_usage(user1, force_new=True)
 
         for i in range(0, 5):
-            self.el3.register_usage(user1)
+            self.el3.register_usage(user1, force_new=True)
 
         for i in range(0, 4):
-            self.el1.register_usage(user1)
+            self.el1.register_usage(user1, force_new=True)
 
         for i in range(0, 2):
-            self.el9.register_usage(user1)
+            self.el9.register_usage(user1, force_new=True)
 
         for i in range(0, 1):
-            self.el10.register_usage(user1)
+            self.el10.register_usage(user1, force_new=True)
 
         response = self.app.get(reverse('team-detail', kwargs={"pk": t.pk}))
 


### PR DESCRIPTION
In order to capture more fine-grained usage of internal applications,
add the concept of “duration” to usage statistics. Two updates in quick
succession (within one hour) will update the duration of the previous 
statistic rather than create a new one.

In the code, a new data point can always be made by passing 
`force_new=True` to `register_usage` — this code exists purely to make 
testing easier and so it is deliberately not exposed via the API.

Also, some existing tests have been updated because they were creating
usage stats in reverse chronological order (which I found confusing when
re-reading them, so I have reordered).
