### PR TITLE
User favourites

### DIFF
--- a/apps/accounts/migrations/0002_user_favourites.py
+++ b/apps/accounts/migrations/0002_user_favourites.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) Crown Owned Copyright, 2016. Dstl.
+
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('links', '0003_add_default_user_and_link'),
+        ('accounts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='favourites',
+            field=models.ManyToManyField(to='links.Link'),
+        ),
+    ]

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -63,6 +63,7 @@ class User(PermissionsMixin, AbstractBaseUser):
     django user model) we also use a slug. Also don't split the user's name
     into first/last for no real reason.
     """
+    from apps.links.models import Link
 
     userid = models.CharField(max_length=256, unique=True)
     slug = models.SlugField(max_length=256, unique=True)
@@ -77,6 +78,7 @@ class User(PermissionsMixin, AbstractBaseUser):
     phone = models.CharField(max_length=256, blank=True, default='')
     email = models.CharField(max_length=256, blank=True, default='')
     teams = models.ManyToManyField(Team)
+    favourites = models.ManyToManyField(Link)
 
     objects = UserManager()
 

--- a/apps/accounts/tests/test_user_favourites_list.py
+++ b/apps/accounts/tests/test_user_favourites_list.py
@@ -1,0 +1,36 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+from django.core.urlresolvers import reverse
+from testing.common import login_user, make_user, generate_fake_links
+
+from django_webtest import WebTest
+
+
+class UserFavouriteLinksListTest(WebTest):
+    def setUp(self):
+        self.logged_in_user = make_user()
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        self.el1, self.el2, = generate_fake_links(
+            self.logged_in_user,
+            count=2,
+            is_external=True
+        )
+
+        self.logged_in_user.favourites.add(self.el1)
+        self.logged_in_user.favourites.add(self.el2)
+
+    def test_list_contains_favourites(self):
+        response = self.app.get(reverse(
+            'user-detail',
+            kwargs={'slug': self.logged_in_user.slug}))
+
+        fav_list = response.html.find(None, {'id': 'favourites-list'})
+
+        self.assertIsNotNone(fav_list)
+
+        fav_list_items = fav_list.findChildren('li')
+
+        self.assertEqual(len(fav_list_items), 2)
+
+        self.assertIn(self.el1.name, fav_list_items[0].text)
+        self.assertIn(self.el2.name, fav_list_items[1].text)

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -12,6 +12,7 @@ from django.views.generic import (
     ListView,
     TemplateView,
     UpdateView,
+    View,
 )
 from django.views.generic.edit import FormView
 
@@ -20,6 +21,7 @@ from .models import User
 from apps.access import LoginRequiredMixin
 from apps.organisations.models import Organisation
 from apps.teams.models import Team
+from apps.links.models import Link
 
 
 class LoginView(FormView):
@@ -350,3 +352,21 @@ class UserList(LoginRequiredMixin, ListView):
         context['total_users_in_db'] = User.objects.count()
 
         return context
+
+
+class UserFavouritesAdd(LoginRequiredMixin, View):
+    def post(self, request, *args, **kwargs):
+        link_id = request.POST.get('link_id')
+        link = Link.objects.get(pk=link_id)
+        link_url = reverse('link-detail', kwargs={'pk': link_id})
+        request.user.favourites.add(link)
+        return HttpResponseRedirect(link_url)
+
+
+class UserFavouritesRemove(LoginRequiredMixin, View):
+    def post(self, request, *args, **kwargs):
+        link_id = request.POST.get('link_id')
+        link = Link.objects.get(pk=link_id)
+        link_url = reverse('link-detail', kwargs={'pk': link_id})
+        request.user.favourites.remove(link)
+        return HttpResponseRedirect(link_url)

--- a/apps/links/tests/test_add_link_to_favourites.py
+++ b/apps/links/tests/test_add_link_to_favourites.py
@@ -1,0 +1,83 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+from django.core.urlresolvers import reverse
+from testing.common import login_user, make_user, generate_fake_links
+
+from django_webtest import WebTest
+
+
+class FavouriteLinksTest(WebTest):
+    def setUp(self):
+        self.logged_in_user = make_user()
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        self.el1, = generate_fake_links(
+            self.logged_in_user,
+            count=1,
+            is_external=True
+        )
+
+    def test_user_can_add_link_to_favourites(self):
+        self.assertNotIn(self.el1, self.logged_in_user.favourites.all())
+
+        def get_elements(response):
+            in_favourites_status = response.html.find(
+                None,
+                {"id": "in-favourites-message"}
+            )
+            not_in_favourites_status = response.html.find(
+                None,
+                {"id": "not-in-favourites-message"}
+            )
+            remove_from_favs_button = response.html.find(
+                None,
+                {"id": "remove-from-favourites"}
+            )
+            add_to_favs_button = response.html.find(
+                None,
+                {"id": "add-to-favourites"}
+            )
+            return (
+                    in_favourites_status,
+                    not_in_favourites_status,
+                    remove_from_favs_button,
+                    add_to_favs_button,
+                    )
+
+        response = self.app.get(
+            reverse('link-detail', kwargs={"pk": self.el1.pk})
+        )
+
+        # Make sure it's not there
+        (in_favourites_status, not_in_favourites_status,
+         remove_from_favs_button, add_to_favs_button,) = get_elements(response)
+
+        self.assertIsNone(in_favourites_status)
+        self.assertIsNotNone(not_in_favourites_status)
+        self.assertIsNone(remove_from_favs_button)
+        self.assertIsNotNone(add_to_favs_button)
+
+        # Now add it
+        form = response.form
+
+        response = form.submit().follow()
+
+        (in_favourites_status, not_in_favourites_status,
+         remove_from_favs_button, add_to_favs_button,) = get_elements(response)
+
+        self.assertIsNotNone(in_favourites_status)
+        self.assertIsNone(not_in_favourites_status)
+        self.assertIsNotNone(remove_from_favs_button)
+        self.assertIsNone(add_to_favs_button)
+
+        # Now remove it
+        form = response.form
+
+        response = form.submit().follow()
+
+        (in_favourites_status, not_in_favourites_status,
+         remove_from_favs_button, add_to_favs_button,) = get_elements(response)
+
+        self.assertIsNone(in_favourites_status)
+        self.assertIsNotNone(not_in_favourites_status)
+        self.assertIsNone(remove_from_favs_button)
+        self.assertIsNotNone(add_to_favs_button)

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -34,6 +34,13 @@ class LinkDetail(DetailView):
     def get_context_data(self, **kwargs):
         context = super(LinkDetail, self).get_context_data(**kwargs)
         context['user_owns_link'] = self.request.user == self.object.owner
+
+        if self.request.user.is_authenticated():
+            is_fav = self.request.user.favourites.filter(
+                id=self.object.id
+            ).exists()
+            context['favourite'] = is_fav
+
         return context
 
 

--- a/lighthouse/urls.py
+++ b/lighthouse/urls.py
@@ -58,6 +58,8 @@ from apps.accounts.views import (
     UserList,
     UserUpdateProfile,
     UserUpdateProfileTeams,
+    UserFavouritesAdd,
+    UserFavouritesRemove,
 )
 
 
@@ -98,6 +100,16 @@ urlpatterns = [
         r'^users/(?P<slug>[\w-]+)/?$',
         UserDetail.as_view(),
         name='user-detail',
+    ),
+    url(
+        r'^users/(?P<slug>[\w-]+)/favourites/add/?$',
+        UserFavouritesAdd.as_view(),
+        name='user-favourites-add',
+    ),
+    url(
+        r'^users/(?P<slug>[\w-]+)/favourites/remove/?$',
+        UserFavouritesRemove.as_view(),
+        name='user-favourites-remove',
     ),
     url(
         r'^links/?$',

--- a/sass/headings.scss
+++ b/sass/headings.scss
@@ -7,3 +7,8 @@
 	@extend .font-small;
 	display: block;
 }
+
+.heading-body {
+	font-weight:bold;
+	margin-bottom:$gutter-half;
+}

--- a/templates/accounts/user_detail.html
+++ b/templates/accounts/user_detail.html
@@ -84,6 +84,7 @@
 
   <div class="column-one-third">
     {% include "includes/top_links_for_user.html" %}
+    {% include "includes/favourite_links_for_user.html" %}
   </div>
 </div>
 

--- a/templates/includes/favourite_links_for_user.html
+++ b/templates/includes/favourite_links_for_user.html
@@ -1,0 +1,17 @@
+{# (c) Crown Owned Copyright, 2016. Dstl. #}
+<h3 class="heading-medium">Favourite tools</h3>
+{% if user.favourites.count > 0 %}
+  <ul class="list list-bullet" id="favourites-list">
+    {% for link in user.favourites.all %}
+      <li><a class="main-list-item" href='{% url "link-detail" link.pk %}'>{{link.name}}</a></li>
+    {% endfor %}
+  </ul>
+{% else %}
+  {% if request.user == user %}
+  <p>You don't have any favourites yet. You can add favourites tools to your
+   profile by pressing the "Add to favourites" button on any Tool's page.
+   <a href="{% url "link-detail" 1 %}">Try it now by adding Lighthouse as one of your favourites</a>.</p>
+  {% else %}
+  <p>This user hasn't added any favourites yet.</p>
+  {% endif %}
+{% endif %}

--- a/templates/links/link_detail.html
+++ b/templates/links/link_detail.html
@@ -96,7 +96,32 @@
         <p>
             Since you added it, you have permission to edit this tool.
         </p>
-        <a class="button" id="edit-button" href="{% url "link-edit" link.id %}">Edit this tool</a>
+        <div class="form-group">
+            <a class="button" id="edit-button" href="{% url "link-edit" link.id %}">Edit this tool</a>
+        </div>
+        {% endif %}
+        {% if favourite %}
+        <form method="post" action="{% url "user-favourites-remove" link.owner.slug %}">
+            {% csrf_token %}
+            <h3 class="heading-body" id="in-favourites-message">
+                This tool is in your favourites
+            </h3>
+            <input type="hidden" name="link_id" value="{{link.id}}">
+            <button class="button" id="remove-from-favourites" type="submit">
+                Remove from favourites
+            </button>
+        </form>
+        {% else %}
+        <form method="post" action="{% url "user-favourites-add" link.owner.slug %}">
+            {% csrf_token %}
+            <h3 class="heading-body" id="not-in-favourites-message">
+                This tool is not yet in your favourites
+            </h3>
+            <input type="hidden" name="link_id" value="{{link.id}}">
+            <button class="button" id="add-to-favourites" value="{{link.id}}">
+                Add to favourites
+            </button>
+        </form>
         {% endif %}
         <h2 class="heading-medium">Categories</h2>
         {% if link.categories.count %}


### PR DESCRIPTION
UserFavourite model as a linker to make a list of favourites.

Had to put it in the links.models module because of circular imports in users.models.
It would have exploded if it hadn't been this way. I wanted to do a M2M relation
using built-in django stuff but it would've been a bit uglier and harder. Instead,
a @property called favourites on the user model seems to be the nicest way to make
the API look the way I want it to look. The user should own the favourites
list, really.

Now the UI Elements for Favourites...

Button: It posts to an endpoint called favourites which is attached to the user,
rather than the other way around. Buttons currently headed with a small
header explaining whether link is in favourite or not.

List: On the User Detail page, the user's favourite Tools are listed
beneath their most used tools.

![2016-04-14 16 32 39-small](https://cloud.githubusercontent.com/assets/516325/14533947/0e19bc0a-025f-11e6-8b39-0f482c99b837.gif)
