### PR TITLE
Update Tools as anybody

### DIFF
--- a/apps/links/migrations/0005_linkedit.py
+++ b/apps/links/migrations/0005_linkedit.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('links', '0004_add_lighthouse_api'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LinkEdit',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True, verbose_name='ID', primary_key=True,
+                    serialize=False)),
+                ('date', models.DateTimeField(auto_now_add=True, null=True)),
+                ('link', models.ForeignKey(
+                    related_name='edits', to='links.Link')),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/apps/links/models.py
+++ b/apps/links/models.py
@@ -33,6 +33,12 @@ class LinkUsage(models.Model):
         return 'Usage of %s by %s at %s' % (self.link, self.user, self.start)
 
 
+class LinkEdit(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    link = models.ForeignKey('Link', related_name='edits')
+    date = models.DateTimeField(auto_now_add=True, blank=True, null=True)
+
+
 class Link(models.Model):
     name = models.CharField(max_length=256)
     description = models.TextField(null=True, blank=True)
@@ -101,6 +107,13 @@ class Link(models.Model):
         ).annotate(
             link_usage_count=models.Count('usage')
         ).order_by('-link_usage_count', 'slug')
+
+    def most_recent_editor(self):
+        edit = self.edits.order_by('-date').first()
+        if edit is None:
+            return None
+
+        return edit.user
 
     #   A somewhat loopy method of getting the top team usage for tools in
     #   the last 30 days. *Because* a user can be a member of more than one

--- a/apps/links/tests/test_create_update.py
+++ b/apps/links/tests/test_create_update.py
@@ -94,13 +94,6 @@ class LinkTest(WebTest):
             edit_button.get('href')
         )
 
-        self.assertTrue(login_user(self, self.other_user))
-
-        response = self.app.get(
-            reverse('link-detail', kwargs={'pk': existing_link.pk}))
-        edit_button = response.html.find(None, {"id": "edit-button"})
-        self.assertIsNone(edit_button)
-
     def test_update_link_external(self):
         existing_link = Link(
             name='Wikimapia',

--- a/apps/links/tests/test_update_as_other_user.py
+++ b/apps/links/tests/test_update_as_other_user.py
@@ -1,0 +1,120 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+
+from django.core.urlresolvers import reverse
+
+from django_webtest import WebTest
+
+from testing.common import make_user, login_user
+from apps.links.models import Link
+
+
+class LinkTest(WebTest):
+    def setUp(self):
+        self.owner_user = make_user(
+            userid='owner',
+            email='fake2@dstl.gov.uk',
+            name='Owner User')
+        self.existing_link = Link(
+            name='Wikimapia',
+            description='A great mapping application',
+            destination='https://wikimapia.org',
+            owner=self.owner_user)
+        self.existing_link.save()
+
+        self.first_editor = make_user(
+            userid='first_editor',
+            email='editor_1@dstl.gov.uk',
+            name='First Editor')
+        self.second_editor = make_user(
+            userid='second_editor',
+            email='editor_2@dstl.gov.uk')
+
+        self.assertTrue(login_user(self, self.first_editor))
+
+    def test_edit_link_button_is_visible_to_non_owner(self):
+        response = self.app.get(
+            reverse('link-detail', kwargs={'pk': self.existing_link.pk}))
+
+        edit_button = response.html.find(None, {'id': 'edit-button'})
+
+        self.assertIsNotNone(edit_button)
+
+    def test_edit_link_submit_works(self):
+        form = self.app.get(
+            reverse('link-edit', kwargs={'pk': self.existing_link.pk})).form
+
+        self.assertEquals(form['name'].value, 'Wikimapia')
+        self.assertEquals(form['description'].value,
+                          'A great mapping application')
+        self.assertEquals(form['destination'].value, 'https://wikimapia.org')
+
+        form['name'].value = 'Bing Maps'
+        form['description'].value = 'A brilliant free mapping application'
+        form['destination'].value = 'https://maps.bing.com'
+
+        response = form.submit().follow()
+
+        self.assertIn('Bing Maps', response)
+        self.assertNotIn('Wikimapia', response)
+        self.assertIn('A brilliant free mapping application', response)
+        self.assertNotIn('A great mapping application', response)
+        self.assertIn('https://maps.bing.com', response)
+        self.assertNotIn('https://wikimapia.org', response)
+
+        owner_element = response.html.find(None, {'id': 'link_owner'})
+
+        self.assertIn(self.owner_user.name, owner_element.text)
+        self.assertIn(self.first_editor.name, owner_element.text)
+
+    def test_editor_stack_stored(self):
+        form = self.app.get(
+            reverse('link-edit', kwargs={'pk': self.existing_link.pk})).form
+
+        # Edit with the first editor
+        self.assertEquals(form['name'].value, 'Wikimapia')
+        self.assertEquals(form['description'].value,
+                          'A great mapping application')
+        self.assertEquals(form['destination'].value, 'https://wikimapia.org')
+
+        form['name'].value = 'Bing Maps'
+        form['description'].value = 'A brilliant free mapping application'
+        form['destination'].value = 'https://maps.bing.com'
+
+        response = form.submit()
+
+        # Login as the second editor
+        self.assertTrue(login_user(self, self.second_editor))
+
+        form = self.app.get(
+            reverse('link-edit', kwargs={'pk': self.existing_link.pk})).form
+
+        # Edit with the second editor
+        form['name'].value = 'Panoramio'
+        form['description'].value = 'A super free mapping application'
+        form['destination'].value = 'https://panoramio.com'
+        # So we can make sure it works in both cases
+        form['is_external'].select('True')
+
+        response = form.submit().follow()
+
+        self.assertIn('Panoramio', response)
+        self.assertNotIn('Bing Maps', response)
+        self.assertIn('A super free mapping application', response)
+        self.assertNotIn('A brilliant mapping application', response)
+        self.assertIn('https://panoramio.com', response)
+        self.assertNotIn('https://maps.bing.com', response)
+
+        owner_element = response.html.find(None, {'id': 'link_owner'})
+
+        # Only show the most recent edit's author
+        self.assertIn(str(self.owner_user), owner_element.text)
+        self.assertNotIn(str(self.first_editor), owner_element.text)
+        self.assertIn(str(self.second_editor), owner_element.text)
+
+        # Store all the edits
+        edits_oldest_first = self.existing_link.edits.order_by('date').all()
+        self.assertEqual(edits_oldest_first[0].user, self.first_editor)
+        self.assertEqual(edits_oldest_first[1].user, self.second_editor)
+        self.assertTrue(
+            edits_oldest_first[1].date > edits_oldest_first[0].date
+        )

--- a/templates/links/link_detail.html
+++ b/templates/links/link_detail.html
@@ -87,21 +87,22 @@
         <span id="is_external" class="external is-external-label">External</span>
         <p id="link_owner">
             {{link.name}} was added by <a href="{% url "user-detail" link.owner.slug %}">{{link.owner}}</a>.
+            {% if link.most_recent_editor %}
+            It was most recently edited by <a href="{% url "user-detail" link.most_recent_editor.slug %}">{{link.most_recent_editor}}</a>.
+            {% endif %}
         </p>
         {% else %}
         <span id="is_internal" class="internal is-internal-label">Internal</span>
         <p id="link_owner">
             {{link.name}} was created by <a href="{% url "user-detail" link.owner.slug %}">{{link.owner}}</a>.
+            {% if link.most_recent_editor %}
+            It was most recently edited by <a href="{% url "user-detail" link.most_recent_editor.slug %}">{{link.most_recent_editor}}</a>.
+            {% endif %}
         </p>
         {% endif %}
-        {% if user_owns_link %}
-        <p>
-            Since you added it, you have permission to edit this tool.
-        </p>
         <div class="form-group">
             <a class="button" id="edit-button" href="{% url "link-edit" link.id %}">Edit this tool</a>
         </div>
-        {% endif %}
         {% if favourite %}
         <form method="post" action="{% url "user-favourites-remove" link.owner.slug %}">
             {% csrf_token %}


### PR DESCRIPTION
This widens the 'Edit' availability to any user whatsoever. Anybody can see the
Edit button and thus anybody can edit a link. However the most recent editor is the only
one shown alongside the owner on the Tool detail page. All the other editors are still stored
with the time they edited (so a list of edits is stored basically, without
any info about the edit itself) but are not shown anywhere yet.

![image](https://cloud.githubusercontent.com/assets/516325/14603085/a601dd3e-0563-11e6-93bb-68685da5ced5.png)
