### PR TITLE
Fix user navigation in the header

### DIFF
--- a/templates/includes/navigation_user_link.html
+++ b/templates/includes/navigation_user_link.html
@@ -1,5 +1,6 @@
 {# (c) Crown Owned Copyright, 2016. Dstl. #}
 
+{% with user=request.user %}
 {% if not user.name %}
   <span class="user_id" data-slug="{{user.slug}}">
     <a href="{% url 'user-updateprofile' user.slug %}" title="You are logged in as {{user}}, and your profile has no display name. Click here to update your profile.">{{user|truncatechars:20}} <span class="profile-prompt-displayname">(add a display name)</span></a>
@@ -22,3 +23,4 @@
   {% endif %}
 {% endif %}
 <a href='{% url "logout" %}'>Logout</a>
+{% endwith %}


### PR DESCRIPTION
`user` in templates is almost always the logged in user, except when
its not — eg when looking at another user’s profile, the `user`
variable becomes the owner of the profile.

Fixes https://trello.com/c/ZrvkUKZe/449-when-you-go-to-someone-else-s-profile-the-header-thinks-you-are-logged-in-as-them
