### PR TITLE
API and Lighthouse now have no visible dest input.

### DIFF
--- a/apps/links/tests/test_lighthouse_edit_page.py
+++ b/apps/links/tests/test_lighthouse_edit_page.py
@@ -1,0 +1,46 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+
+from django.core.urlresolvers import reverse
+
+from django_webtest import WebTest
+
+from testing.common import make_user, login_user, generate_fake_links
+
+
+class LighthouseGoToTest(WebTest):
+    def test_lighthouse_edit_page_has_no_destination_box(self):
+        self.logged_in_user = make_user()
+        self.app.get(reverse('login'))
+
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        response = self.app.get(reverse('link-edit', kwargs={'pk': 1}))
+
+        dest_input = response.html.find('input', {'name': 'destination'})
+
+        self.assertEqual(dest_input.attrs['type'], 'hidden')
+
+    def test_lighthouse_api_edit_page_has_no_destination_box(self):
+        self.logged_in_user = make_user()
+        self.app.get(reverse('login'))
+
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        response = self.app.get(reverse('link-edit', kwargs={'pk': 2}))
+
+        dest_input = response.html.find('input', {'name': 'destination'})
+
+        self.assertEqual(dest_input.attrs['type'], 'hidden')
+
+    def test_normal_edit_page_has_destination_box(self):
+        self.logged_in_user = make_user()
+        self.app.get(reverse('login'))
+        link, = generate_fake_links(owner=self.logged_in_user)
+
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        response = self.app.get(reverse('link-edit', kwargs={'pk': link.id}))
+
+        dest_input = response.html.find('input', {'name': 'destination'})
+
+        self.assertEqual(dest_input.attrs['type'], 'url')

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -118,12 +118,24 @@ class LinkCreate(LoginRequiredMixin, CategoriesFormMixin, CreateView):
         'name', 'description', 'destination', 'is_external', 'categories'
     ]
 
+    def get_context_data(self, **kwargs):
+        context = super(LinkCreate, self).get_context_data(**kwargs)
+        context['not_lighthouse_link'] = True
+
+        return context
+
 
 class LinkUpdate(LoginRequiredMixin, CategoriesFormMixin, UpdateView):
     model = Link
     fields = [
         'name', 'description', 'destination', 'is_external', 'categories'
     ]
+
+    def get_context_data(self, **kwargs):
+        context = super(LinkUpdate, self).get_context_data(**kwargs)
+        context['not_lighthouse_link'] = self.object.pk not in [1, 2]
+
+        return context
 
 
 class LinkList(ListView):

--- a/templates/links/link_form.html
+++ b/templates/links/link_form.html
@@ -146,6 +146,7 @@
     <input class="form-control" id="{{ form.categories.id_for_label }}" value="" maxlength="256" name="categories" type="text" />
   </div>
 
+  {% if not_lighthouse_link %}
   <div class="form-group{% if form.destination.errors %} error{% endif %}" id="{{ form.destination.id_for_label }}_group">
     <label class="form-label-bold" for="{{ form.destination.id_for_label }}">
       Destination
@@ -164,6 +165,9 @@
     {% endif %}
     <input class="form-control" id="{{ form.destination.id_for_label }}" value="{{ form.destination.value|default_if_none:"" }}" maxlength="2000" name="destination" type="url" />
   </div>
+  {% else %}
+    <input id="{{ form.destination.id_for_label }}" value="{{ form.destination.value|default_if_none:"" }}" name="destination" type="hidden" />
+  {% endif %}
 
   <input type="submit" method="POST" value="Save tool" class="button" />
 </form>


### PR DESCRIPTION
This is because there was a bug where the input wanted to validate the url, but
in the Lighthouse and Lighthouse API links are relative URLs, so the form got
pretty angry.

https://trello.com/c/rzpNGJHk/450-if-you-edit-the-lighthouse-or-lighthouse-api-tools-you-cannot-save-because-the-url-is-a-relative-url

So anyway, this PR puts a hidden input in place of the url input if it's one of
the aforementioned links.

![image](https://cloud.githubusercontent.com/assets/516325/14608085/2c1c7240-057c-11e6-9ea6-d1cb93b5661c.png)
