### PR TITLE
Autofocus & tabindex fixes

### DIFF
--- a/templates/includes/team_form_team_as_team.html
+++ b/templates/includes/team_form_team_as_team.html
@@ -11,6 +11,6 @@
     {% endfor %}
   </ul>
   {% endif %}
-  <input class="form-control" id="{{ form.name.id_for_label }}" maxlength="256" name="name" type="text" value="{{ form.name.value|default_if_none:"" }}">
+  <input class="form-control" id="{{ form.name.id_for_label }}" maxlength="256" name="name" type="text" autofocus="true" value="{{ form.name.value|default_if_none:"" }}">
 </div>
 

--- a/templates/includes/team_form_team_as_teamname.html
+++ b/templates/includes/team_form_team_as_teamname.html
@@ -11,6 +11,6 @@
     {% endfor %}
   </ul>
   {% endif %}
-  <input class="form-control" id="{{ form.teamname.id_for_label }}" maxlength="256" name="teamname" type="text" value="{{ form.teamname.value|default_if_none:"" }}">
+  <input class="form-control" id="{{ form.teamname.id_for_label }}" autofocus="true" maxlength="256" name="teamname" type="text" value="{{ form.teamname.value|default_if_none:"" }}">
 </div>
 

--- a/templates/links/link_form.html
+++ b/templates/links/link_form.html
@@ -54,7 +54,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <input class="form-control" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:"" }}" maxlength="256" name="name" type="text" tabindex="1" autofocus="true" />
+    <input class="form-control" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:"" }}" maxlength="256" name="name" type="text" autofocus="true" />
   </div>
   <div class="form-group{% if form.description.errors %} error{% endif %}">
     <label class="form-label-bold" for="{{ form.description.id_for_label }}">

--- a/templates/links/link_list.html
+++ b/templates/links/link_list.html
@@ -44,7 +44,7 @@
     </div>
     <div class="column-two-thirds">
       <div class="form-group two-thirds-inline-search-form">
-        <input class="form-control search-box" type='text' name='q' id='q' tabindex="1" autofocus="true" value="{{query|default_if_none:''}}" />
+        <input class="form-control search-box" type='text' name='q' id='q' autofocus="true" value="{{query|default_if_none:''}}" />
         <button class="button search-button" type="submit">Search</button>
       </div>
       {% if object_list %}

--- a/templates/organisations/organisation_list.html
+++ b/templates/organisations/organisation_list.html
@@ -58,7 +58,7 @@
           <p class="form-hint">
             If an organisation isn't in the list above then you can add it here.
           </p>
-          <input class="form-control" id="id_name" maxlength="256" name="name" type="text" tabindex="1" />
+          <input class="form-control" id="id_name" maxlength="256" name="name" type="text"  />
         </div>
         <input type="submit" method="POST" value="Add organisation" class="button">
       </form>

--- a/templates/users/user_details_form.html
+++ b/templates/users/user_details_form.html
@@ -60,7 +60,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <input class="form-control" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:"" }}" maxlength="256" name="name" type="text"{% if highlight_field ==  form.name.id_for_label %} tabindex="1" autofocus="true"{% endif %} />
+    <input class="form-control" id="{{ form.name.id_for_label }}" value="{{ form.name.value|default_if_none:"" }}" maxlength="256" name="name" type="text"{% if highlight_field ==  form.name.id_for_label %} autofocus="true"{% endif %} />
 
   </div>
 


### PR DESCRIPTION
Some of the tabindex attributes were messing up the order of elements on the page
so they've been removed and some new autofocus elements have been put in. No longer
will you start on the team element then tab to the 'Skip to main content' part
