### PR TITLE
Swapped search & tool stats links in header

### DIFF
--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -17,8 +17,8 @@
           <li><a href="{% url 'link-list' %}">All tools</a></li>
           <li><a href="{% url 'link-create' %}">Add a new tool</a></li>
           <li><a href="{% url 'user-list' %}">All users</a></li>
-          <li class="pull-right"><a href="{% url 'link-overall-stats' %}">Tool stats</a></li>
           <li class="pull-right"><a href="{% url 'search-stats' %}">Search stats</a></li>
+          <li class="pull-right"><a href="{% url 'link-overall-stats' %}">Tool stats</a></li>
         </ul>
       {% endif %}
       


### PR DESCRIPTION
The tool stats link should be more prominent as it's more important
