### PR TITLE
Exclude Lighthouse API on overall stats pg

### DIFF
--- a/apps/links/tests/test_usage_logging.py
+++ b/apps/links/tests/test_usage_logging.py
@@ -270,6 +270,17 @@ class LinkUsageWebTest(WebTest):
         self.assertEquals(link_stats_cells[3].text, '2')
         self.assertEquals(other_link_stats_cells[3].text, '1')
 
+    def test_link_stats_page_excludes_api(self):
+        lighthouse_api_link = Link.objects.get(id=2)
+        lighthouse_api_link.register_usage(self.user)
+
+        stats_url = reverse('link-overall-stats')
+        response = self.app.get(stats_url)
+
+        api_stats = response.html.find('tr', id='stats-for-2')
+
+        self.assertIsNone(api_stats)
+
     def test_internal_link_usage(self):
         detail_url = reverse('link-detail', kwargs={'pk': self.link.pk})
 

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -302,7 +302,7 @@ class OverallLinkStats(ListView):
 
     def get_queryset(self):
         return sorted(
-            Link.objects.annotate(Count('usage')),
+            Link.objects.exclude(id=2).annotate(Count('usage')),
             key=lambda o: (o.usage_past_thirty_days()),
             reverse=True
         )


### PR DESCRIPTION
It should still be visible in the CSV, but not on the page with the table itself.
Completes: https://trello.com/c/9k2i2jMy/460-hide-lighthouse-api-from-stats-list
