### PR TITLE
Highlight external tools in overall stats

### DIFF
--- a/apps/links/tests/test_usage_logging.py
+++ b/apps/links/tests/test_usage_logging.py
@@ -255,8 +255,14 @@ class LinkUsageWebTest(WebTest):
         other_link_stats_cells = other_link_stats.findChildren('td')
 
         # Name
-        self.assertEquals(link_stats_cells[0].text, self.link.name)
-        self.assertEquals(other_link_stats_cells[0].text, self.other_link.name)
+        self.assertEquals(
+            link_stats_cells[0].get_text(strip=True),
+            self.link.name
+        )
+        self.assertEquals(
+            other_link_stats_cells[0].get_text(strip=True),
+            '%sExternal' % self.other_link.name,
+        )
 
         # Thirty
         self.assertEquals(link_stats_cells[1].text, '2')
@@ -478,6 +484,7 @@ class LinkUsageWebTest(WebTest):
             'Duration': '0',
             'Date': '2016-03-01 10:00:00',
             'Tool': 'Link Linkerly',
+            'External?': '',
         })
 
         row = next(reader)
@@ -486,6 +493,7 @@ class LinkUsageWebTest(WebTest):
             'Duration': '60',
             'Date': '2016-03-01 11:15:00',
             'Tool': 'Other Link',
+            'External?': 'External',
         })
 
         row = next(reader)
@@ -494,6 +502,7 @@ class LinkUsageWebTest(WebTest):
             'Duration': '0',
             'Date': '2016-03-01 13:00:00',
             'Tool': 'Link Linkerly',
+            'External?': '',
         })
 
     def test_usage_detail_page_three_periods(self):

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -316,13 +316,17 @@ class OverallLinkStatsCSV(LoginRequiredMixin, View):
             'attachment; filename="lighthouse_full_%s.csv"' % date
 
         writer = csv.writer(response)
-        writer.writerow(['Date', 'Duration', 'User', 'Tool'])
+        writer.writerow(['Date', 'Duration', 'User', 'Tool', 'External?'])
         for usage in LinkUsage.objects.all():
+            external = ''
+            if usage.link.is_external:
+                external = 'External'
             writer.writerow([
                 usage.start.strftime("%Y-%m-%d %H:%M:%S"),
                 usage.duration,
                 usage.user.userid,
-                usage.link
+                usage.link,
+                external,
             ])
 
         return response

--- a/sass/table.scss
+++ b/sass/table.scss
@@ -14,5 +14,9 @@ table.stats_table {
   th.usage-seven-days {
     background: #ffffdd;
   }
+  .is-external-label {
+    font-size: 0.8em;
+    float: right;
+  }
   margin-bottom:$gutter;
 }

--- a/templates/links/link_overall_stats.html
+++ b/templates/links/link_overall_stats.html
@@ -27,7 +27,12 @@
     </tr>
     {% for link in object_list %}
       <tr id="stats-for-{{link.pk}}">
-        <td><a href='{% url "link-detail" link.pk %}'>{{link.name}}</a></td>
+        <td>
+          <a href='{% url "link-detail" link.pk %}'>{{link.name}}</a>
+          {% if link.is_external %}
+            <span class='is-external-label'>External</span>
+          {% endif %}
+        </td>
         <td class='usage-thirty-days'>{{link.usage_past_thirty_days}}</td>
         <td class='usage-seven-days'>{{link.usage_past_seven_days}}</td>
         <td class='usage-total'>{{link.usage.count}}</td>


### PR DESCRIPTION
The overall stats page on the site now has “External” next to external
tools in the table. The downloadable CSV has a new column which is
either blank or contains “External”.

![stats](https://cloud.githubusercontent.com/assets/32136/14713418/f4e9c322-07d8-11e6-9fec-8601d78d370a.png)

Closes https://trello.com/c/gPMdc8Kf/454-flag-external-tools-in-the-stats-table-as-being-external-because-the-stats-have-different-implications-also-add-it-as-a-field-to
