### PR TITLE
Filter by favourites

### DIFF
--- a/apps/links/search_indexes.py
+++ b/apps/links/search_indexes.py
@@ -30,6 +30,7 @@ class VariationCharField(indexes.CharField):
 
 
 class LinkIndex(indexes.SearchIndex, indexes.Indexable):
+    key = indexes.CharField(indexed=True, model_attr='pk')
     name = indexes.CharField(model_attr='name')
     categories = indexes.MultiValueField(indexed=True, stored=True)
     text = VariationCharField(document=True, use_template=True)

--- a/apps/links/tests/test_list_filter_favourites.py
+++ b/apps/links/tests/test_list_filter_favourites.py
@@ -1,0 +1,119 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+
+from django.core.urlresolvers import reverse
+
+from django_webtest import WebTest
+
+from testing.common import generate_fake_links, login_user, make_user
+from haystack.management.commands import rebuild_index
+
+
+class ListFavouriteLinksTest(WebTest):
+    def setUp(self):
+        self.logged_in_user = make_user()
+
+        (self.el1, self.el2, self.el3,) = generate_fake_links(
+            self.logged_in_user,
+            count=3
+        )
+
+        self.el1.categories.add('mapping')
+        self.el1.save()
+
+        self.el2.categories.add('mapping')
+        self.el2.save()
+
+        self.el3.categories.add('social')
+        self.el3.save()
+
+        self.el3.name = 'Unique'
+        self.el3.save()
+
+        self.logged_in_user.favourites.add(self.el2)
+        self.logged_in_user.favourites.add(self.el3)
+
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        rebuild_index.Command().handle(interactive=False, verbosity=0)
+
+    def test_favourite_checkbox(self):
+        response = self.app.get(reverse('link-list'))
+
+        filterEl = response.html.find(id='categories-filter')
+
+        favouritesLbl = filterEl.find(attrs={'for': 'filter-favourites'})
+        favouritesCheckbox = filterEl.find(id='filter-favourites')
+        self.assertIsNotNone(favouritesLbl)
+        self.assertIsNotNone(favouritesCheckbox)
+        self.assertEquals(favouritesCheckbox.attrs['value'], 'true')
+        self.assertFalse('checked' in favouritesCheckbox.attrs)
+
+    def test_favourite_filter(self):
+        response = self.app.get(reverse('link-list'))
+
+        form = response.forms['list-results']
+
+        self.assertEquals(
+            form.get('favourites', index=0).id, 'filter-favourites'
+        )
+        form.get('favourites', index=0).checked = True
+
+        response = form.submit()
+        form = response.forms['list-results']
+
+        self.assertEquals(
+            len(response.html.findAll('li', {'class': 'link-list-item'})),
+            2
+        )
+
+        self.assertIsNone(response.html.find('ol', {'class': 'pagination'}))
+
+        self.assertIn(
+            self.el3.name,
+            response.html.findAll(
+                'li',
+                {'class': 'link-list-item'}
+            )[0].text,
+        )
+
+        self.assertIn(
+            self.el2.name,
+            response.html.findAll(
+                'li',
+                {'class': 'link-list-item'}
+            )[1].text,
+        )
+
+        self.assertTrue(form.get('favourites', index=0).checked)
+
+    def test_favourite_and_query_filter(self):
+        response = self.app.get(reverse('link-list'))
+
+        form = response.forms['list-results']
+
+        self.assertEquals(
+            form.get('favourites', index=0).id, 'filter-favourites'
+        )
+        form.get('favourites', index=0).checked = True
+
+        form['q'] = self.el3.name
+
+        response = form.submit()
+        form = response.forms['list-results']
+
+        self.assertEquals(
+            len(response.html.findAll('li', {'class': 'link-list-item'})),
+            1
+        )
+
+        self.assertIsNone(response.html.find('ol', {'class': 'pagination'}))
+
+        self.assertIn(
+            self.el3.name,
+            response.html.findAll(
+                'li',
+                {'class': 'link-list-item'}
+            )[0].text,
+        )
+
+        self.assertTrue(form.get('favourites', index=0).checked)

--- a/apps/links/tests/test_usage_logging.py
+++ b/apps/links/tests/test_usage_logging.py
@@ -255,9 +255,9 @@ class LinkUsageWebTest(WebTest):
         other_link_stats_cells = other_link_stats.findChildren('td')
 
         # Name
-        self.assertEquals(
-            link_stats_cells[0].get_text(strip=True),
-            self.link.name
+        self.assertIn(
+            self.link.name,
+            link_stats_cells[0].get_text(strip=True)
         )
         self.assertEquals(
             other_link_stats_cells[0].get_text(strip=True),

--- a/templates/links/link_list.html
+++ b/templates/links/link_list.html
@@ -20,6 +20,13 @@
       <input type="submit" value="Filter using selections below" class="button" />
     </div>
     <div class="form-group">
+      <div class="form-group">
+        {# Favourites filters #}
+        <label for="filter-favourites" class="block-label block-label-small">
+          <h3>My favourites</h3>
+          <input type="checkbox" id="filter-favourites" value="true" name="favourites" {% if favourites_filtered %}checked="checked"{% endif %} />
+        </label>
+      </div>
       {% for category in categories %}
       <label for="categories-filter-{{ category.name }}" class="block-label block-label-small">
         <h3>{{ category.name|capfirst }}</h3>


### PR DESCRIPTION
There's now a checkbox on the tool list page for 'My favourites'
which, when checked, will be applied along with any other filters
currently applied.

In order to do this, the ID needs to be indexed (as "key") so that
haystack can filter on it, with an array of IDs which is built from the
user's favourites.

![image](https://cloud.githubusercontent.com/assets/516325/14738877/02aa4790-087c-11e6-87f7-f0deb301f7cf.png)
