### PR TITLE
Add a 'your favourites' link to tool deets

### DIFF
--- a/templates/links/link_detail.html
+++ b/templates/links/link_detail.html
@@ -107,7 +107,7 @@
         <form method="post" action="{% url "user-favourites-remove" link.owner.slug %}">
             {% csrf_token %}
             <h3 class="heading-body" id="in-favourites-message">
-                This tool is in your favourites
+                This tool is in <a href="{% url "link-list" %}?favourites=true">your favourites</a>.
             </h3>
             <input type="hidden" name="link_id" value="{{link.id}}">
             <button class="button" id="remove-from-favourites" type="submit">
@@ -118,7 +118,7 @@
         <form method="post" action="{% url "user-favourites-add" link.owner.slug %}">
             {% csrf_token %}
             <h3 class="heading-body" id="not-in-favourites-message">
-                This tool is not yet in your favourites
+                This tool is not yet in <a href="{% url "link-list" %}?favourites=true">your favourites</a>.
             </h3>
             <input type="hidden" name="link_id" value="{{link.id}}">
             <button class="button" id="add-to-favourites" value="{{link.id}}">


### PR DESCRIPTION
**NOTE**: Please merge #193 first.

The tool details page says whether you've added the tool to your favourites, with no
way of seeing aforementioned favourites. This has been remedied.

![image](https://cloud.githubusercontent.com/assets/516325/14741929/75e7e040-0891-11e6-947e-0ead6509be83.png)
