### PR TITLE
[DO NOT MERGE] Automatically log users in based on environment

### DIFF
--- a/apps/access/__init__.py
+++ b/apps/access/__init__.py
@@ -19,7 +19,7 @@ class LoginUsingEnvironmentMixin(object):
     in the environment.
     """
     def dispatch(self, request, *args, **kwargs):
-        user = getenv('REMOTE_USER')
+        user = getenv('KEYCLOAK_USERNAME')
         if user and user != request.user.userid:
             return self.handle_no_permission()
         return super(LoginUsingEnvironmentMixin, self).dispatch(

--- a/apps/access/__init__.py
+++ b/apps/access/__init__.py
@@ -4,11 +4,26 @@
 # - haystack supports django 1.9
 # - haystack is no longer a dependency
 
+from os import getenv
+
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.utils.encoding import force_text
+
+
+class LoginUsingEnvironmentMixin(object):
+    """
+    Verify that the current logged-in user matches the user passed
+    in the environment.
+    """
+    def dispatch(self, request, *args, **kwargs):
+        user = getenv('REMOTE_USER')
+        if user and user != request.user.userid:
+            return self.handle_no_permission()
+        return super(LoginUsingEnvironmentMixin, self).dispatch(
+            request, *args, **kwargs)
 
 
 class AccessMixin(object):
@@ -57,7 +72,7 @@ class AccessMixin(object):
         )
 
 
-class LoginRequiredMixin(AccessMixin):
+class LoginRequiredMixin(LoginUsingEnvironmentMixin, AccessMixin):
     """
     CBV mixin which verifies that the current user is authenticated.
     """

--- a/apps/accounts/tests/test_user_login.py
+++ b/apps/accounts/tests/test_user_login.py
@@ -253,7 +253,7 @@ class UserWebTest(WebTest):
 
 class EnvironmentLoginTest(WebTest):
     def test_auto_login(self):
-        os.environ['REMOTE_USER'] = 'user@0001.com'
+        os.environ['KEYCLOAK_USERNAME'] = 'user@0001.com'
 
         response = self.app.get(reverse('login'))
         self.assertEqual(
@@ -261,12 +261,12 @@ class EnvironmentLoginTest(WebTest):
             response.location
         )
 
-        os.environ.pop('REMOTE_USER')
+        os.environ.pop('KEYCLOAK_USERNAME')
 
     def test_auto_login_for_admin(self):
         get_user_model().objects.create_user(
             userid='admin@0001.com', password='password')
-        os.environ['REMOTE_USER'] = 'admin@0001.com'
+        os.environ['KEYCLOAK_USERNAME'] = 'admin@0001.com'
 
         response = self.app.get(reverse('login'))
         self.assertEqual(
@@ -274,4 +274,4 @@ class EnvironmentLoginTest(WebTest):
             response.location
         )
 
-        os.environ.pop('REMOTE_USER')
+        os.environ.pop('KEYCLOAK_USERNAME')

--- a/apps/accounts/tests/test_user_login.py
+++ b/apps/accounts/tests/test_user_login.py
@@ -1,5 +1,7 @@
 # (c) Crown Owned Copyright, 2016. Dstl.
 
+import os
+
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 
@@ -247,3 +249,29 @@ class UserWebTest(WebTest):
         self.assertTrue(slug_link)
         slug_text = slug_link.text
         self.assertIn('User 0001', slug_text)
+
+
+class EnvironmentLoginTest(WebTest):
+    def test_auto_login(self):
+        os.environ['REMOTE_USER'] = 'user@0001.com'
+
+        response = self.app.get(reverse('login'))
+        self.assertEqual(
+            'http://localhost:80/users/user0001com/update-profile',
+            response.location
+        )
+
+        os.environ.pop('REMOTE_USER')
+
+    def test_auto_login_for_admin(self):
+        get_user_model().objects.create_user(
+            userid='admin@0001.com', password='password')
+        os.environ['REMOTE_USER'] = 'admin@0001.com'
+
+        response = self.app.get(reverse('login'))
+        self.assertEqual(
+            'http://localhost:80/users/admin0001com/update-profile',
+            response.location
+        )
+
+        os.environ.pop('REMOTE_USER')

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -62,7 +62,7 @@ class LoginView(FormView):
 
     def get_initial(self):
         initial = super(LoginView, self).get_initial()
-        initial['userid'] = os.getenv('REMOTE_USER')
+        initial['userid'] = os.getenv('KEYCLOAK_USERNAME')
         return initial
 
     def get_success_url(self):
@@ -110,7 +110,7 @@ class LoginView(FormView):
         Same as django.views.generic.edit.ProcessFormView.get(),
         but adds test cookie stuff
         """
-        userid = os.getenv('REMOTE_USER')
+        userid = os.getenv('KEYCLOAK_USERNAME')
         if userid:
             try:
                 user = get_user_model().objects.get(userid=userid)


### PR DESCRIPTION
If `REMOTE_USER` is set in the environment, django will trust it and
login the account with that userid (creating it if necessary).
