### PR TITLE
Don't validate dest for Lighthouse/API

### DIFF
--- a/apps/links/forms.py
+++ b/apps/links/forms.py
@@ -1,0 +1,20 @@
+# (c) Crown Owned Copyright, 2016. Dstl.
+
+from django import forms
+from .models import Link
+
+
+class LinkUpdateForm(forms.ModelForm):
+    class Meta:
+        model = Link
+        fields = [
+            'name', 'description', 'destination', 'is_external', 'categories'
+        ]
+
+    def full_clean(self):
+        c = super(LinkUpdateForm, self).full_clean()
+
+        if self.instance.pk in [1, 2] and 'destination' in self._errors:
+            del self._errors['destination']
+
+        return c

--- a/apps/links/tests/test_lighthouse_edit_page.py
+++ b/apps/links/tests/test_lighthouse_edit_page.py
@@ -32,6 +32,28 @@ class LighthouseGoToTest(WebTest):
 
         self.assertEqual(dest_input.attrs['type'], 'hidden')
 
+    def test_lighthouse_api_edit_page_can_submit(self):
+        self.logged_in_user = make_user()
+        self.app.get(reverse('login'))
+
+        self.assertTrue(login_user(self, self.logged_in_user))
+
+        response = self.app.get(reverse('link-edit', kwargs={'pk': 2}))
+        form = response.form
+
+        new_desc = 'I love the Lighthouse API'
+        form['description'] = new_desc
+
+        response = form.submit().follow()
+
+        error_summary = response.html.find('div', {"class": "error-summary"})
+        self.assertIsNone(error_summary)
+
+        description = response.html.find(
+            'div', {"class": "markdown-content"})
+
+        self.assertIn(new_desc, description.text)
+
     def test_normal_edit_page_has_destination_box(self):
         self.logged_in_user = make_user()
         self.app.get(reverse('login'))

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -20,6 +20,7 @@ from django.views.generic import (
 from taggit.models import Tag
 
 from .models import Link, LinkUsage, LinkEdit
+from .forms import LinkUpdateForm
 from apps.access import LoginRequiredMixin
 
 from haystack.inputs import AutoQuery
@@ -134,9 +135,7 @@ class LinkCreate(LoginRequiredMixin, CategoriesFormMixin, CreateView):
 
 class LinkUpdate(LoginRequiredMixin, CategoriesFormMixin, UpdateView):
     model = Link
-    fields = [
-        'name', 'description', 'destination', 'is_external', 'categories'
-    ]
+    form_class = LinkUpdateForm
 
     def get_context_data(self, **kwargs):
         context = super(LinkUpdate, self).get_context_data(**kwargs)


### PR DESCRIPTION
Both of the default links, Lighthouse and Lighthouse API, have 'invalid' URLs
according to django. This means that when the models are saved the validation blows
up the attempt. So a custom form class was introduced to make it possible to save
without this field preventing due to validation errors
