### PR TITLE
Stop filter buttons flashing when JS is on

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -38,6 +38,16 @@ class LoginView(FormView):
     def dispatch(self, *args, **kwargs):
         return super(LoginView, self).dispatch(*args, **kwargs)
 
+    def has_js(self):
+        js_qs = self.request.POST.get('js', None)
+        if js_qs == 'false':
+            return False
+        elif js_qs == 'true':
+            js_qs = True
+
+        js_session = self.request.session.get('has_js', False) is True
+        return js_qs or js_session
+
     def form_valid(self, form):
         """
         The user has provided valid credentials (this was checked in
@@ -107,6 +117,19 @@ class LoginView(FormView):
         """
         self.set_test_cookie()
         return super(LoginView, self).get(request, *args, **kwargs)
+
+    def post(self, request):
+        """
+        Just need to save whether JS is available in the session
+        """
+        result = super(LoginView, self).post(request)
+
+        if self.has_js():
+            self.request.session['has_js'] = True
+        else:
+            self.request.session['has_js'] = False
+
+        return result
 
 
 class LogoutView(LoginRequiredMixin, TemplateView):

--- a/apps/links/views.py
+++ b/apps/links/views.py
@@ -283,6 +283,7 @@ class LinkList(LoginRequiredMixin, ListView):
         context['filtered_types'] = types_to_filter
         context['total_links_in_db'] = Link.objects.count()
         context['favourites_filtered'] = self.has_favourites()
+        context['has_js'] = self.request.session.get('has_js', False)
 
         context['extra_query_strings'] = '&'.join(querystrings)
 

--- a/static/lighthouse.js
+++ b/static/lighthouse.js
@@ -16,4 +16,9 @@ $(document).ready(function() {
   // and focused states for block labels
   var $blockLabels = $(".block-label input[type='radio'], .block-label input[type='checkbox']");
   new GOVUK.SelectionButtons($blockLabels);
+
+  $('#jsinput').attr('name', 'js');
+  if ($('#jsinput').val() !== 'false') {
+    $('#jsinput').val('true')
+  }
 });

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -15,6 +15,10 @@
         Please use your normal system ID to log in here.
       </p>
       <input class="form-control" id="id_userid" maxlength="256" name="userid" type="text" autofocus="true">
+      {% if has_js %}
+      {% else %}
+      <input type="hidden" id="jsinput" value="true">
+      {% endif %}
     </div>
     <input type="submit" method="POST" value="Login" class="button button-start">
   </form>

--- a/templates/links/link_list.html
+++ b/templates/links/link_list.html
@@ -16,7 +16,7 @@
   <div id="categories-filter" class="column-third">
     <h2 class="filter-controls-header heading-medium heading-snug-top">Tool categories</h2>
     {# Category filters #}
-    <div class="form-group">
+    <div class="form-group{% if has_js %} hidden{% endif %}">
       <input type="submit" value="Filter using selections below" class="button" />
     </div>
     <div class="form-group">
@@ -45,7 +45,7 @@
           <input type="checkbox" id="types-filter-internal" value="internal" name="types" {% if 'internal' in filtered_types %}checked="checked"{% endif %} />
         </label>
       </div>
-      <div class="form-group">
+      <div class="form-group{% if has_js %} hidden{% endif %}">
         <input type="submit" value="Filter" class="button" />
       </div>
     </div>


### PR DESCRIPTION
When JavaScript is available, the filter buttons are hidden so that merely
clicking the checkboxes will filter the page. Now, the filter buttons
will already be hidden if a context var says they should be.

This context var gets its information from a session variable that is
set when the user logs on. When the user logs in, some JS runs to make a
hidden input part of a form by giving it a 'name' attribute. This hidden
input, whose name is 'js', is used as part of the login POST and sets
the session variable to indicate whether the user has JS or not.

The result is the filter buttons being pre-hidden if the user definitely
has JS.
