### PR TITLE
Make login with "full" profile go to all links

### DIFF
--- a/apps/accounts/tests/test_user_landing.py
+++ b/apps/accounts/tests/test_user_landing.py
@@ -1,13 +1,48 @@
 # (c) Crown Owned Copyright, 2016. Dstl.
 
+from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django_webtest import WebTest
-from unittest.case import skip
+
+from apps.teams.models import Team
+from apps.organisations.models import Organisation
 
 
 class KeycloakHeaderLandAtHome(WebTest):
-    @skip
     def test_auto_login_on_landing(self):
         headers = {'KEYCLOAK_USERNAME': 'user@0001.com'}
-        response = self.app.get(reverse('home'), headers=headers)
-        self.assertEqual('http://localhost:80/links', response.location)
+        first_step = self.app.get(reverse('home'), headers=headers)
+        self.assertEqual('http://localhost:80/login', first_step.location)
+
+        second_response = self.app.get(first_step.location, headers=headers)
+        self.assertEqual(
+            'http://localhost:80/users/user0001com/update-profile',
+            second_response.location
+        )
+
+    def test_auto_login_on_landing_for_full_profile(self):
+        o = Organisation(name='org0001')
+        o.save()
+        t = Team(name='team0001', organisation=o)
+        t.save()
+
+        user = get_user_model().objects.create_user(
+            userid='user@0001.com',
+            name='User 0001',
+            best_way_to_find='In the kitchen',
+            best_way_to_contact='By email',
+            phone='00000000',
+            email='user@0001.com',
+        )
+        user.teams.add(t)
+        user.save()
+
+        headers = {'KEYCLOAK_USERNAME': 'user@0001.com'}
+        first_step = self.app.get(reverse('home'), headers=headers)
+        self.assertEqual('http://localhost:80/login', first_step.location)
+
+        second_response = self.app.get(first_step.location, headers=headers)
+        self.assertEqual(
+            'http://localhost:80/links',
+            second_response.location
+        )

--- a/apps/accounts/tests/test_user_login.py
+++ b/apps/accounts/tests/test_user_login.py
@@ -187,6 +187,33 @@ class UserWebTest(WebTest):
             'Please add additional information'
         )
 
+    def test_user_with_full_profile_goes_to_links(self):
+        #   This user has a username and teams
+        o = Organisation(name='org0001')
+        o.save()
+        t = Team(name='team0001', organisation=o)
+        t.save()
+
+        user = get_user_model().objects.create_user(
+            userid='user@0001.com',
+            name='User 0001',
+            best_way_to_find='In the kitchen',
+            best_way_to_contact='By email',
+            phone='00000000',
+            email='user@0001.com',
+        )
+        user.teams.add(t)
+        user.save()
+
+        #   Log in as user
+        form = self.app.get(reverse('login')).form
+        form['userid'] = 'user@0001.com'
+        response = form.submit().follow()
+        self.assertIn(
+            'All tools',
+            response.html.find('h1').text
+        )
+
     #   Check that a link showing the user's slug appears in the top nav
     #   bar
     def test_slug_and_link_exists_in_nav(self):
@@ -266,5 +293,30 @@ class KeycloakHeaderLoginTest(WebTest):
         response = self.app.get(reverse('login'), headers=headers)
         self.assertEqual(
             'http://localhost:80/users/admin0001com/update-profile',
+            response.location
+        )
+
+    def test_auto_login_for_complete_profile_goes_to_links(self):
+        #   This user has a username and teams
+        o = Organisation(name='org0001')
+        o.save()
+        t = Team(name='team0001', organisation=o)
+        t.save()
+
+        user = get_user_model().objects.create_user(
+            userid='user@0001.com',
+            name='User 0001',
+            best_way_to_find='In the kitchen',
+            best_way_to_contact='By email',
+            phone='00000000',
+            email='user@0001.com',
+        )
+        user.teams.add(t)
+        user.save()
+
+        headers = {'KEYCLOAK_USERNAME': 'user@0001.com'}
+        response = self.app.get(reverse('login'), headers=headers)
+        self.assertEqual(
+            'http://localhost:80/links',
             response.location
         )

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -108,7 +108,8 @@ class LoginView(FormView):
                 kwargs={'slug': self.user.slug}
             )
 
-        return reverse('user-detail', kwargs={'slug': self.user.slug})
+        # Full profile means go to the list of links
+        return reverse('link-list')
 
     def set_test_cookie(self):
         self.request.session.set_test_cookie()


### PR DESCRIPTION
Previously, logging in having already filled out the full profile would
redirect the user to their profile -- the idea being that they would
get links to *their* most used tools.

Now, redirect to the full list of tools. For a newer user, having a list
of all tools available is deemed more useful.